### PR TITLE
fix: use actual protocol-specified timestamp format (milliseconds)

### DIFF
--- a/src/db/migration/mod.rs
+++ b/src/db/migration/mod.rs
@@ -11,14 +11,16 @@ mod add_account_kind;
 mod add_next_msg_ids;
 mod initial_db_version;
 mod remove_log_chan_id_from_admin_keys;
+mod timestamps_are_milliseconds;
 
 type Migration = for<'a> fn(&'a Db) -> BoxFuture<'a, DbResult<()>>;
 
-pub const MIGRATIONS: [Migration; 4] = [
+pub const MIGRATIONS: [Migration; 5] = [
     initial_db_version::migrate,
     add_next_msg_ids::migrate,
     remove_log_chan_id_from_admin_keys::migrate,
     add_account_kind::migrate,
+    timestamps_are_milliseconds::migrate,
 ];
 
 pub async fn get_db_version(db: &Db) -> DbResult<(usize, bool)> {

--- a/src/db/migration/timestamps_are_milliseconds.rs
+++ b/src/db/migration/timestamps_are_milliseconds.rs
@@ -1,0 +1,33 @@
+use super::*;
+
+use db::{
+    rkyv_ser, Batch
+};
+use harmony_rust_sdk::api::chat::Message as HarmonyMessage;
+
+pub(super) fn migrate(db: &Db) -> BoxFuture<'_, DbResult<()>> {
+    let fut = async move {
+        let chat_tree = db.open_tree(b"chat").await?;
+        let mut batch = Batch::default();
+        let pfix = [];
+
+        for res in chat_tree.scan_prefix(&pfix).await {
+            let (key, val) = res?;
+
+            let message = rkyv::from_bytes::<HarmonyMessage>(&val);
+            let Ok(mut msg) = message else {
+                continue;
+            };
+
+            msg.created_at *= 1000;
+            msg.edited_at = msg.edited_at.map(|x| x * 1000);
+
+            batch.insert(key, rkyv_ser(&msg));
+        }
+
+        chat_tree.apply_batch(batch).await?;
+        Ok(())
+    };
+
+    Box::pin(fut)
+}

--- a/src/impls/chat/mod.rs
+++ b/src/impls/chat/mod.rs
@@ -34,7 +34,7 @@ use triomphe::Arc;
 use crate::{
     db::{self, chat::*, rkyv_ser, Batch, Db, DbResult},
     impls::{
-        get_time_secs,
+        get_time_millisecs,
         prelude::*,
         rest::download::{calculate_range, get_file_full, get_file_handle, is_id_jpeg, read_bufs},
         sync::EventDispatch,
@@ -1505,7 +1505,7 @@ impl ChatTree {
         let message_id = self.get_next_message_id(guild_id, channel_id).await?;
         let key = make_msg_key(guild_id, channel_id, message_id); // [tag:msg_key_u64]
 
-        let created_at = get_time_secs();
+        let created_at = get_time_millisecs();
         let edited_at = None;
 
         let message = HarmonyMessage {

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -11,6 +11,13 @@ pub use ratelimit::rate_limit;
 
 use smol_str::SmolStr;
 
+pub fn get_time_millisecs() -> u64 {
+    std::time::UNIX_EPOCH
+        .elapsed()
+        .expect("time is before unix epoch")
+        .as_millis() as u64
+}
+
 pub fn get_time_secs() -> u64 {
     std::time::UNIX_EPOCH
         .elapsed()


### PR DESCRIPTION
Scherzo using seconds isn't in line with the Harmony protocol, and has confused
clients, which inconsistently interpret timestamps as either milliseconds and
seconds. Some [clients](https://github.com/harmony-development/tempest) even use both meanings in the same application. Making sure
Scherzo uses the correct format will help to resolve this confusion.